### PR TITLE
Optimize custom metrics path using GetMetricsData API and batching

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -56,17 +56,20 @@ type Static struct {
 }
 
 type CustomMetrics struct {
-	Regions                []string  `yaml:"regions"`
-	Name                   string    `yaml:"name"`
-	Namespace              string    `yaml:"namespace"`
-	Roles                  []Role    `yaml:"roles"`
-	Metrics                []*Metric `yaml:"metrics"`
-	Statistics             []string  `yaml:"statistics"`
-	NilToZero              *bool     `yaml:"nilToZero"`
-	Period                 int64     `yaml:"period"`
-	Length                 int64     `yaml:"length"`
-	Delay                  int64     `yaml:"delay"`
-	AddCloudwatchTimestamp *bool     `yaml:"addCloudwatchTimestamp"`
+	Regions                   []string  `yaml:"regions"`
+	Name                      string    `yaml:"name"`
+	Namespace                 string    `yaml:"namespace"`
+	Roles                     []Role    `yaml:"roles"`
+	Metrics                   []*Metric `yaml:"metrics"`
+	Statistics                []string  `yaml:"statistics"`
+	NilToZero                 *bool     `yaml:"nilToZero"`
+	Period                    int64     `yaml:"period"`
+	Length                    int64     `yaml:"length"`
+	Delay                     int64     `yaml:"delay"`
+	AddCloudwatchTimestamp    *bool     `yaml:"addCloudwatchTimestamp"`
+	CustomTags                []Tag     `yaml:"customTags"`
+	DimensionNameRequirements []string  `yaml:"dimensionNameRequirements"`
+	RoundingPeriod            *int64    `yaml:"roundingPeriod"`
 }
 
 type Role struct {


### PR DESCRIPTION
The upstream code calls `GetMetricStatistics` `<N>` times where N is the number of unique time-series which is really expensive. 

This PR re-uses some of the functions used in the auto-discovery job to use `GetMetricsData` API and also batch API calls to save cost.

![Screenshot 2022-10-31 at 7 33 18 PM](https://user-images.githubusercontent.com/3872649/199026476-a7b9bcdd-559f-445a-8ab5-9bafd58b2c25.png)

https://segment.atlassian.net/browse/BDCI-219
