### PR TITLE
Don't skip CloudWatch GetMetricData API calls if dimensions don't match tagged resources

### DIFF
--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -226,7 +226,6 @@ func scrapeDiscoveryJobUsingMetricData(
 
 	if len(resources) == 0 {
 		logger.Info("No tagged resources made it through filtering")
-		return
 	}
 
 	svc := SupportedServices.GetService(job.Type)

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -298,8 +298,6 @@ func getFilteredMetricDatas(region string, accountId *string, namespace string, 
 		}
 	}
 	for _, cwMetric := range metricsList {
-		skip := false
-		alreadyFound := false
 		r := &taggedResource{
 			ARN:       "global",
 			Namespace: namespace,
@@ -311,37 +309,31 @@ func getFilteredMetricDatas(region string, accountId *string, namespace string, 
 		for _, dimension := range cwMetric.Dimensions {
 			if dimensionFilterValues, ok := dimensionsFilter[*dimension.Name]; ok {
 				if d, ok := dimensionFilterValues[*dimension.Value]; !ok {
-					if !alreadyFound {
-						skip = true
-					}
 					break
 				} else {
-					alreadyFound = true
 					r = d
 				}
 			}
 		}
 
-		if !skip {
-			for _, stats := range m.Statistics {
-				id := fmt.Sprintf("id_%d", rand.Int())
-				metricTags := r.metricTags(tagsOnMetrics)
-				getMetricsData = append(getMetricsData, cloudwatchData{
-					ID:                     &r.ARN,
-					MetricID:               &id,
-					Metric:                 &m.Name,
-					Namespace:              &namespace,
-					Statistics:             []string{stats},
-					NilToZero:              m.NilToZero,
-					AddCloudwatchTimestamp: m.AddCloudwatchTimestamp,
-					Tags:                   metricTags,
-					CustomTags:             customTags,
-					Dimensions:             cwMetric.Dimensions,
-					Region:                 &region,
-					AccountId:              accountId,
-					Period:                 int64(m.Period),
-				})
-			}
+		for _, stats := range m.Statistics {
+			id := fmt.Sprintf("id_%d", rand.Int())
+			metricTags := r.metricTags(tagsOnMetrics)
+			getMetricsData = append(getMetricsData, cloudwatchData{
+				ID:                     &r.ARN,
+				MetricID:               &id,
+				Metric:                 &m.Name,
+				Namespace:              &namespace,
+				Statistics:             []string{stats},
+				NilToZero:              m.NilToZero,
+				AddCloudwatchTimestamp: m.AddCloudwatchTimestamp,
+				Tags:                   metricTags,
+				CustomTags:             customTags,
+				Dimensions:             cwMetric.Dimensions,
+				Region:                 &region,
+				AccountId:              accountId,
+				Period:                 int64(m.Period),
+			})
 		}
 	}
 	return getMetricsData


### PR DESCRIPTION
To follow-up after this PR with YACE maintainers the best approach long term.

[BDCI-121](https://segment.atlassian.net/browse/BDCI-121)