### PR TITLE
Support untagged resources only if a flag supportUntagged is set 

### DIFF
--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -197,7 +197,7 @@ func getMetricDataForQueries(
 		if len(resources) == 0 {
 			logger.Debug("No resources for metric", "metric_name", metric.Name, "namespace", svc.Namespace)
 		}
-		getMetricDatas = append(getMetricDatas, getFilteredMetricDatas(region, accountId, discoveryJob.Type, discoveryJob.CustomTags, tagsOnMetrics, svc.DimensionRegexps, resources, metricsList.Metrics, discoveryJob.DimensionNameRequirements, metric)...)
+		getMetricDatas = append(getMetricDatas, getFilteredMetricDatas(region, accountId, discoveryJob.Type, discoveryJob.CustomTags, tagsOnMetrics, svc.DimensionRegexps, resources, metricsList.Metrics, discoveryJob.DimensionNameRequirements, discoveryJob.SupportUntagged, metric)...)
 	}
 	return getMetricDatas
 }

--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -470,6 +470,7 @@ func getMetricDataForQueriesToFetchCustomMetrics(
 			[]*taggedResource{},
 			metricsList.Metrics,
 			customMetricJob.DimensionNameRequirements,
+			customMetricJob.SupportUntagged,
 			metric,
 		)...)
 	}

--- a/pkg/aws_cloudwatch_test.go
+++ b/pkg/aws_cloudwatch_test.go
@@ -70,6 +70,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 		tagsOnMetrics             exportedTagsOnMetrics
 		dimensionRegexps          []*string
 		dimensionNameRequirements []string
+		supportUntagged           bool
 		resources                 []*taggedResource
 		metricsList               []*cloudwatch.Metric
 		m                         *Metric
@@ -459,7 +460,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metricDatas := getFilteredMetricDatas(tt.args.region, tt.args.accountId, tt.args.namespace, tt.args.customTags, tt.args.tagsOnMetrics, tt.args.dimensionRegexps, tt.args.resources, tt.args.metricsList, tt.args.dimensionNameRequirements, tt.args.m)
+			metricDatas := getFilteredMetricDatas(tt.args.region, tt.args.accountId, tt.args.namespace, tt.args.customTags, tt.args.tagsOnMetrics, tt.args.dimensionRegexps, tt.args.resources, tt.args.metricsList, tt.args.dimensionNameRequirements, tt.args.supportUntagged, tt.args.m)
 			if len(metricDatas) != len(tt.wantGetMetricsData) {
 				t.Errorf("len(getFilteredMetricDatas()) = %v, want %v", len(metricDatas), len(tt.wantGetMetricsData))
 			}

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -33,6 +33,7 @@ type Job struct {
 	Roles                     []Role    `yaml:"roles"`
 	SearchTags                []Tag     `yaml:"searchTags"`
 	CustomTags                []Tag     `yaml:"customTags"`
+	SupportUntagged           bool      `yaml:"supportUntagged"`
 	DimensionNameRequirements []string  `yaml:"dimensionNameRequirements"`
 	Metrics                   []*Metric `yaml:"metrics"`
 	Length                    int64     `yaml:"length"`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -69,6 +69,7 @@ type CustomMetrics struct {
 	Delay                     int64     `yaml:"delay"`
 	AddCloudwatchTimestamp    *bool     `yaml:"addCloudwatchTimestamp"`
 	CustomTags                []Tag     `yaml:"customTags"`
+	SupportUntagged           bool      `yaml:"supportUntagged"`
 	DimensionNameRequirements []string  `yaml:"dimensionNameRequirements"`
 	RoundingPeriod            *int64    `yaml:"roundingPeriod"`
 }


### PR DESCRIPTION
The solution for supporting untagged resources caused the number of GetMetricsAPI to 3x because the discovery process via resource tagging used to, by side-effect filter out deleted resources (i.e terminated EC2 instance) and the new solution bypassed it.

To work around this, the change is now feature flagged so that we can disabled it for resources where we expect a lot of creation/deletions to take place (eg: EC2).

[BDCI-121](https://segment.atlassian.net/browse/BDCI-121)